### PR TITLE
Add Maven CI workflow and fix test parsing bug

### DIFF
--- a/.github/workflows/maven-test.yml
+++ b/.github/workflows/maven-test.yml
@@ -1,0 +1,23 @@
+name: Maven Tests
+
+on:
+  push:
+    branches: [develop, master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Run tests
+        run: mvn test

--- a/.github/workflows/maven-test.yml
+++ b/.github/workflows/maven-test.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Set up Java
         uses: actions/setup-java@v4
         with:
-          java-version: '17'
+          java-version: '25'
           distribution: 'temurin'
 
       - name: Run tests

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ProjectModuleManager">
-    <modules>
-      <module fileurl="file://$PROJECT_DIR$/search.iml" filepath="$PROJECT_DIR$/search.iml" />
-    </modules>
-  </component>
-</project>

--- a/src/test/java/com/epam/tests/QueenBreadthSearchTest.java
+++ b/src/test/java/com/epam/tests/QueenBreadthSearchTest.java
@@ -41,11 +41,15 @@ public class QueenBreadthSearchTest {
         for (String line : buffer.toString().trim().split("\n")) {
             String[] tokens = line.trim().split("\\s+");
             if (tokens.length == N) {
-                int[] sol = new int[N];
-                for (int i = 0; i < N; i++) {
-                    sol[i] = Integer.parseInt(tokens[i]) - 1;
+                try {
+                    int[] sol = new int[N];
+                    for (int i = 0; i < N; i++) {
+                        sol[i] = Integer.parseInt(tokens[i]) - 1;
+                    }
+                    solutions.add(sol);
+                } catch (NumberFormatException e) {
+                    // skip summary lines (e.g. "BFS Всего решений: 2")
                 }
-                solutions.add(sol);
             }
         }
         return solutions;

--- a/src/test/java/com/epam/tests/QueenDepthSearchTest.java
+++ b/src/test/java/com/epam/tests/QueenDepthSearchTest.java
@@ -41,11 +41,15 @@ public class QueenDepthSearchTest {
         for (String line : buffer.toString().trim().split("\n")) {
             String[] tokens = line.trim().split("\\s+");
             if (tokens.length == N) {
-                int[] sol = new int[N];
-                for (int i = 0; i < N; i++) {
-                    sol[i] = Integer.parseInt(tokens[i]) - 1;
+                try {
+                    int[] sol = new int[N];
+                    for (int i = 0; i < N; i++) {
+                        sol[i] = Integer.parseInt(tokens[i]) - 1;
+                    }
+                    solutions.add(sol);
+                } catch (NumberFormatException e) {
+                    // skip summary lines (e.g. "DFS Всего решений: 2")
                 }
-                solutions.add(sol);
             }
         }
         return solutions;


### PR DESCRIPTION
## Summary

- Add `.github/workflows/maven-test.yml` to run `mvn test` automatically on every push to `develop`/`master` and on every PR targeting `master`
- Fix `NumberFormatException` in `captureSolutions` in both test classes — summary lines like `"DFS Всего решений: 2"` were accidentally matching `tokens.length == N` for certain values of N, causing a parse error